### PR TITLE
Added Github workflow to run pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,14 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: reuse
+name: pre-commit
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
-  test:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: reuse Compliance Check
-      uses: fsfe/reuse-action@v1
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
@kevinl-rivosinc should we remove the reuse workflow as it's covered by the pre-commit workflow? 