### PR TITLE
Update license headers and pre-commit hooks for 2026/Python 3.14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/build-and-test-jumpstart.yaml
+++ b/.github/workflows/build-and-test-jumpstart.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,12 @@ repos:
       - id: black
 
   - repo: https://github.com/ikamensh/flynt/
-    rev: 1.0.2
+    rev: 1.0.3
     hooks:
       - id: flynt
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,9 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: JumpStart
+Upstream-Contact: Rivos Inc.
+Source: https://github.com/rivosinc/JumpStart
+
+# Files from Meta
+Files: CODE_OF_CONDUCT.md CONTRIBUTING.md
+Copyright: Meta Platforms, Inc.
+License: Apache-2.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rivos Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rivos Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Contributing to JumpStart
 We want to make contributing to this project as easy and transparent as
 possible.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/docs/jumpstart_internals.md
+++ b/docs/jumpstart_internals.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/docs/quick_start_anatomy_of_a_diag.md
+++ b/docs/quick_start_anatomy_of_a_diag.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/docs/reference_manual.md
+++ b/docs/reference_manual.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/include/common/cpu_bits.h
+++ b/include/common/cpu_bits.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/delay.h
+++ b/include/common/delay.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/heap.smode.h
+++ b/include/common/heap.smode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/jumpstart.h
+++ b/include/common/jumpstart.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/lock.h
+++ b/include/common/lock.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/lock.mmode.h
+++ b/include/common/lock.mmode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/lock.smode.h
+++ b/include/common/lock.smode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/tablewalk.smode.h
+++ b/include/common/tablewalk.smode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/time.mmode.h
+++ b/include/common/time.mmode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/time.smode.h
+++ b/include/common/time.smode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/uart.h
+++ b/include/common/uart.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/uart.mmode.h
+++ b/include/common/uart.mmode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/uart.smode.h
+++ b/include/common/uart.smode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/utils.mmode.h
+++ b/include/common/utils.mmode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/common/utils.smode.h
+++ b/include/common/utils.smode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/meson.build
+++ b/meson.build
@@ -72,10 +72,8 @@ if get_option('run_target') == 'spike'
 
   else
     if spike_isa_string == ''
-      spike_isa_string = 'rv64gcvh_zba_zbb_zbs_zkr_svpbmt_smstateen_zicntr'
+      spike_isa_string = 'rv64gcvh_zba_zbb_zbs_zkr_svpbmt_smstateen_zicntr_zicclsm'
     endif
-
-    default_spike_args += ['--misaligned']
 
   endif
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/build_diag.py
+++ b/scripts/build_diag.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/build_tools/__init__.py
+++ b/scripts/build_tools/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/build_tools/diag.py
+++ b/scripts/build_tools/diag.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/build_tools/diag_factory.py
+++ b/scripts/build_tools/diag_factory.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/build_tools/environment.py
+++ b/scripts/build_tools/environment.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/build_tools/environments.yaml
+++ b/scripts/build_tools/environments.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/build_tools/meson.py
+++ b/scripts/build_tools/meson.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/data_structures/__init__.py
+++ b/scripts/data_structures/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/data_structures/bitfield_utils.py
+++ b/scripts/data_structures/bitfield_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/data_structures/cstruct.py
+++ b/scripts/data_structures/cstruct.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/data_structures/dict_utils.py
+++ b/scripts/data_structures/dict_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/data_structures/list_utils.py
+++ b/scripts/data_structures/list_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/generate_diag_sources.py
+++ b/scripts/generate_diag_sources.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/memory_management/__init__.py
+++ b/scripts/memory_management/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/memory_management/linker_script.py
+++ b/scripts/memory_management/linker_script.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/memory_management/memory_mapping.py
+++ b/scripts/memory_management/memory_mapping.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/memory_management/page_size.py
+++ b/scripts/memory_management/page_size.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/memory_management/page_tables.py
+++ b/scripts/memory_management/page_tables.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/public/functions.py
+++ b/scripts/public/functions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/system/functions.py
+++ b/scripts/system/functions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -1,3 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/scripts/utils/binary_utils.py
+++ b/scripts/utils/binary_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/utils/generate_batch_test_manifest.py
+++ b/scripts/utils/generate_batch_test_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/utils/napot_utils.py
+++ b/scripts/utils/napot_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/common/data.privileged.S
+++ b/src/common/data.privileged.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/heap.smode.S
+++ b/src/common/heap.smode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/heap.smode.c
+++ b/src/common/heap.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/jumpstart.mmode.S
+++ b/src/common/jumpstart.mmode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/jumpstart.smode.S
+++ b/src/common/jumpstart.smode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/jumpstart.umode.S
+++ b/src/common/jumpstart.umode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/jumpstart.vsmode.S
+++ b/src/common/jumpstart.vsmode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/jumpstart.vumode.S
+++ b/src/common/jumpstart.vumode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/lock.mmode.c
+++ b/src/common/lock.mmode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/lock.smode.c
+++ b/src/common/lock.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/meson.build
+++ b/src/common/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/common/sbi_firmware_boot.smode.S
+++ b/src/common/sbi_firmware_boot.smode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/string.smode.c
+++ b/src/common/string.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/tablewalk.smode.c
+++ b/src/common/tablewalk.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/thread_attributes.mmode.c
+++ b/src/common/thread_attributes.mmode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/thread_attributes.smode.c
+++ b/src/common/thread_attributes.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/time.mmode.c
+++ b/src/common/time.mmode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/time.smode.c
+++ b/src/common/time.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/trap_handler.mmode.c
+++ b/src/common/trap_handler.mmode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/trap_handler.smode.c
+++ b/src/common/trap_handler.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/uart.mmode.c
+++ b/src/common/uart.mmode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/uart.smode.c
+++ b/src/common/uart.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/utils.mmode.c
+++ b/src/common/utils.mmode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/common/utils.smode.c
+++ b/src/common/utils.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/public/exit.mmode.S
+++ b/src/public/exit.mmode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/public/init.mmode.S
+++ b/src/public/init.mmode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/public/jump_to_main.mmode.S
+++ b/src/public/jump_to_main.mmode.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/public/jumpstart_public_source_attributes.yaml
+++ b/src/public/jumpstart_public_source_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/public/meson.build
+++ b/src/public/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/public/uart/meson.build
+++ b/src/public/uart/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/src/public/uart/uart.mmode.c
+++ b/src/public/uart/uart.mmode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/public/uart/uart.smode.c
+++ b/src/public/uart/uart.smode.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test000/test000.c
+++ b/tests/common/test000/test000.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test000/test000.diag_attributes.yaml
+++ b/tests/common/test000/test000.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test001/test001.c
+++ b/tests/common/test001/test001.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test001/test001.diag_attributes.yaml
+++ b/tests/common/test001/test001.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test002/test002.S
+++ b/tests/common/test002/test002.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test002/test002.c
+++ b/tests/common/test002/test002.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test002/test002.diag_attributes.yaml
+++ b/tests/common/test002/test002.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test003/test003.S
+++ b/tests/common/test003/test003.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test003/test003.c
+++ b/tests/common/test003/test003.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test003/test003.diag_attributes.yaml
+++ b/tests/common/test003/test003.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test006/test006.c
+++ b/tests/common/test006/test006.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test006/test006.diag_attributes.yaml
+++ b/tests/common/test006/test006.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test010/test010.c
+++ b/tests/common/test010/test010.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test010/test010.diag_attributes.yaml
+++ b/tests/common/test010/test010.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test011/test011.S
+++ b/tests/common/test011/test011.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test011/test011.c
+++ b/tests/common/test011/test011.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test011/test011.diag_attributes.yaml
+++ b/tests/common/test011/test011.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test012/test012.c
+++ b/tests/common/test012/test012.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test012/test012.diag_attributes.yaml
+++ b/tests/common/test012/test012.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test013/test013.c
+++ b/tests/common/test013/test013.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test013/test013.diag_attributes.yaml
+++ b/tests/common/test013/test013.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test014/test014.c
+++ b/tests/common/test014/test014.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test014/test014.diag_attributes.yaml
+++ b/tests/common/test014/test014.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test017/test017.S
+++ b/tests/common/test017/test017.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test017/test017.c
+++ b/tests/common/test017/test017.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test017/test017.diag_attributes.yaml
+++ b/tests/common/test017/test017.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test018/test018.S
+++ b/tests/common/test018/test018.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test018/test018.c
+++ b/tests/common/test018/test018.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test018/test018.diag_attributes.yaml
+++ b/tests/common/test018/test018.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test019/test019.c
+++ b/tests/common/test019/test019.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test019/test019.diag_attributes.yaml
+++ b/tests/common/test019/test019.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test020/test020.c
+++ b/tests/common/test020/test020.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test020/test020.diag_attributes.yaml
+++ b/tests/common/test020/test020.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test021/test021.S
+++ b/tests/common/test021/test021.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test021/test021.c
+++ b/tests/common/test021/test021.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test021/test021.diag_attributes.yaml
+++ b/tests/common/test021/test021.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test022/test022.c
+++ b/tests/common/test022/test022.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test022/test022.diag_attributes.yaml
+++ b/tests/common/test022/test022.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test023/test023.S
+++ b/tests/common/test023/test023.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test023/test023.c
+++ b/tests/common/test023/test023.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test023/test023.diag_attributes.yaml
+++ b/tests/common/test023/test023.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test026/test026.S
+++ b/tests/common/test026/test026.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test026/test026.c
+++ b/tests/common/test026/test026.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test026/test026.diag_attributes.yaml
+++ b/tests/common/test026/test026.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test027/test027.S
+++ b/tests/common/test027/test027.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test027/test027.c
+++ b/tests/common/test027/test027.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test027/test027.diag_attributes.yaml
+++ b/tests/common/test027/test027.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test028/meson_option_overrides.yaml
+++ b/tests/common/test028/meson_option_overrides.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test028/test028.S
+++ b/tests/common/test028/test028.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test028/test028.c
+++ b/tests/common/test028/test028.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test028/test028.diag_attributes.yaml
+++ b/tests/common/test028/test028.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test029/meson_option_overrides.yaml
+++ b/tests/common/test029/meson_option_overrides.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test029/test029.S
+++ b/tests/common/test029/test029.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test029/test029.c
+++ b/tests/common/test029/test029.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test029/test029.diag_attributes.yaml
+++ b/tests/common/test029/test029.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test030/test030.c
+++ b/tests/common/test030/test030.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test030/test030.diag_attributes.yaml
+++ b/tests/common/test030/test030.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test031/test031.c
+++ b/tests/common/test031/test031.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test031/test031.diag_attributes.yaml
+++ b/tests/common/test031/test031.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test033/test033.c
+++ b/tests/common/test033/test033.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test033/test033.diag_attributes.yaml
+++ b/tests/common/test033/test033.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test036/test036.S
+++ b/tests/common/test036/test036.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test036/test036.c
+++ b/tests/common/test036/test036.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test036/test036.diag_attributes.yaml
+++ b/tests/common/test036/test036.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test037/test037.S
+++ b/tests/common/test037/test037.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test037/test037.c
+++ b/tests/common/test037/test037.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test037/test037.diag_attributes.yaml
+++ b/tests/common/test037/test037.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test038/test038.S
+++ b/tests/common/test038/test038.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test038/test038.c
+++ b/tests/common/test038/test038.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test038/test038.diag_attributes.yaml
+++ b/tests/common/test038/test038.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test040/test040.S
+++ b/tests/common/test040/test040.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test040/test040.c
+++ b/tests/common/test040/test040.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test040/test040.diag_attributes.yaml
+++ b/tests/common/test040/test040.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test041/test041.S
+++ b/tests/common/test041/test041.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test041/test041.c
+++ b/tests/common/test041/test041.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test041/test041.diag_attributes.yaml
+++ b/tests/common/test041/test041.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test042/test042.S
+++ b/tests/common/test042/test042.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test042/test042.c
+++ b/tests/common/test042/test042.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test042/test042.diag_attributes.yaml
+++ b/tests/common/test042/test042.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test044/test044.c
+++ b/tests/common/test044/test044.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test044/test044.diag_attributes.yaml
+++ b/tests/common/test044/test044.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test045/test045.S
+++ b/tests/common/test045/test045.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test045/test045.c
+++ b/tests/common/test045/test045.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test045/test045.diag_attributes.yaml
+++ b/tests/common/test045/test045.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test046/test046.S
+++ b/tests/common/test046/test046.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test046/test046.c
+++ b/tests/common/test046/test046.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test046/test046.diag_attributes.yaml
+++ b/tests/common/test046/test046.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test047/test047.S
+++ b/tests/common/test047/test047.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test047/test047.c
+++ b/tests/common/test047/test047.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test047/test047.diag_attributes.yaml
+++ b/tests/common/test047/test047.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test048/test048.S
+++ b/tests/common/test048/test048.S
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test048/test048.c
+++ b/tests/common/test048/test048.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test048/test048.diag_attributes.yaml
+++ b/tests/common/test048/test048.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test049/test049.c
+++ b/tests/common/test049/test049.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test049/test049.diag_attributes.yaml
+++ b/tests/common/test049/test049.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test050/test050.c
+++ b/tests/common/test050/test050.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test050/test050.diag_attributes.yaml
+++ b/tests/common/test050/test050.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2024 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test051/test051.c
+++ b/tests/common/test051/test051.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test051/test051.diag_attributes.yaml
+++ b/tests/common/test051/test051.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test052/test052.c
+++ b/tests/common/test052/test052.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test052/test052.diag_attributes.yaml
+++ b/tests/common/test052/test052.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test053/test053.c
+++ b/tests/common/test053/test053.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test053/test053.diag_attributes.yaml
+++ b/tests/common/test053/test053.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test058/test058.c
+++ b/tests/common/test058/test058.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test058/test058.diag_attributes.yaml
+++ b/tests/common/test058/test058.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test061/test061.diag_attributes.yaml
+++ b/tests/common/test061/test061.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test067/test067.c
+++ b/tests/common/test067/test067.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test067/test067.diag_attributes.yaml
+++ b/tests/common/test067/test067.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/common/test070/test070.c
+++ b/tests/common/test070/test070.c
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Rivos Inc.
+ * SPDX-FileCopyrightText: 2025 - 2026 Rivos Inc.
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/tests/common/test070/test070.diag_attributes.yaml
+++ b/tests/common/test070/test070.diag_attributes.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 - 2025 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
## Summary

This PR includes two updates to keep the repository current:

1. **License header updates for 2026** - Updated copyright year in license headers

2. **Pre-commit hook compatibility for Python 3.14** - Updated hooks that were failing due to Python 3.14 breaking changes:
   - `flynt`: 1.0.2 → 1.0.3 (fixes `ast.Str` removal in Python 3.12+)
   - `pyupgrade`: v3.20.0 → v3.21.2 (fixes `tokenize.cookie_re` bytes/string incompatibility)

## Testing

- Ran `pre-commit clean` to clear cached environments
- Verified pre-commit hooks install and run successfully with Python 3.14
